### PR TITLE
test: cover cached cwd contracts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
       - name: Test default features
-        run: cargo test --locked --workspace
+        run: cargo test --locked -p sugar_path
       - name: Test all features
         run: cargo test --locked --workspace --all-features
 

--- a/tests/cached_current_dir.rs
+++ b/tests/cached_current_dir.rs
@@ -5,7 +5,7 @@ use std::{
   time::{SystemTime, UNIX_EPOCH},
 };
 
-use sugar_path::{SugarPath, SugarPathBuf};
+use sugar_path::SugarPath;
 
 fn assert_owned_relative(target: &Path, base: &Path, expected: &Path, context: &str) {
   let strict = target.relative(base);
@@ -49,12 +49,6 @@ fn current_directory_is_cached_only_when_requested() {
   let first = env::current_dir().expect("read the first temporary directory");
   let dirty_absolute = first.join("unused").join("..").join("absolute.js");
   assert_eq!(dirty_absolute.absolutize(), first.join("absolute.js"));
-  assert_owned_relative(
-    Path::new("pkg/assets/./index.js"),
-    Path::new("pkg/chunks"),
-    &PathBuf::from("..").join("assets").join("index.js"),
-    "cwd-independent relative",
-  );
 
   env::set_current_dir(&second).expect("enter the second temporary directory");
   let second = env::current_dir().expect("read the second temporary directory");
@@ -62,14 +56,6 @@ fn current_directory_is_cached_only_when_requested() {
   let anchor = root.join("anchor");
   let second_name = second.file_name().expect("second directory has a name");
   let second_target = second.join("absolute-target.js");
-  let relative_target = Path::new("../second/relative-target.js");
-  let relative_base = Path::new("base");
-  assert_owned_relative(
-    relative_target,
-    relative_base,
-    &PathBuf::from("..").join("relative-target.js"),
-    "unequal-parent relative pair initializes cwd",
-  );
   assert_owned_relative(
     Path::new("entry.js"),
     &anchor,
@@ -88,43 +74,6 @@ fn current_directory_is_cached_only_when_requested() {
   let third = env::current_dir().expect("read the third temporary directory");
   let expected_base = if cfg!(feature = "cached_current_dir") { &second } else { &third };
   let expected_base_name = expected_base.file_name().expect("expected base has a name");
-  let expected_relative_pair = if cfg!(feature = "cached_current_dir") {
-    PathBuf::from("..").join("relative-target.js")
-  } else {
-    PathBuf::from("..").join("..").join(second_name).join("relative-target.js")
-  };
-  assert_owned_relative(
-    relative_target,
-    relative_base,
-    &expected_relative_pair,
-    "unequal-parent relative pair observes cwd policy",
-  );
-  let expected_slash = if cfg!(feature = "cached_current_dir") {
-    "../relative-target.js"
-  } else {
-    "../../second/relative-target.js"
-  };
-  assert_eq!(
-    relative_target.relative(relative_base).into_owned().into_slash(),
-    expected_slash,
-    "strict relative-to-slash composition observes cwd policy",
-  );
-  assert_eq!(
-    relative_target
-      .try_relative(relative_base)
-      .expect("fixture should resolve against cwd")
-      .into_owned()
-      .into_slash(),
-    expected_slash,
-    "fallible relative-to-slash composition observes cwd policy",
-  );
-  let explicit = relative_target.relative_with(relative_base, &third);
-  assert_eq!(
-    explicit.as_os_str(),
-    PathBuf::from("..").join("..").join(second_name).join("relative-target.js").as_os_str(),
-    "explicit cwd must bypass ambient caching",
-  );
-  assert!(matches!(explicit, Cow::Owned(_)), "explicit unequal-parent result should own");
   assert_owned_relative(
     Path::new("entry.js"),
     &anchor,

--- a/tests/cached_current_dir.rs
+++ b/tests/cached_current_dir.rs
@@ -1,10 +1,21 @@
 use std::{
+  borrow::Cow,
   env, fs,
   path::{Path, PathBuf},
   time::{SystemTime, UNIX_EPOCH},
 };
 
-use sugar_path::SugarPath;
+use sugar_path::{SugarPath, SugarPathBuf};
+
+fn assert_owned_relative(target: &Path, base: &Path, expected: &Path, context: &str) {
+  let strict = target.relative(base);
+  assert_eq!(strict.as_os_str(), expected.as_os_str(), "{context} strict");
+  assert!(matches!(strict, Cow::Owned(_)), "{context} strict should own");
+
+  let fallible = target.try_relative(base).expect("fixture should resolve against cwd");
+  assert_eq!(fallible.as_os_str(), expected.as_os_str(), "{context} try");
+  assert!(matches!(fallible, Cow::Owned(_)), "{context} try should own");
+}
 
 struct CurrentDirGuard {
   original: PathBuf,
@@ -38,14 +49,99 @@ fn current_directory_is_cached_only_when_requested() {
   let first = env::current_dir().expect("read the first temporary directory");
   let dirty_absolute = first.join("unused").join("..").join("absolute.js");
   assert_eq!(dirty_absolute.absolutize(), first.join("absolute.js"));
+  assert_owned_relative(
+    Path::new("pkg/assets/./index.js"),
+    Path::new("pkg/chunks"),
+    &PathBuf::from("..").join("assets").join("index.js"),
+    "cwd-independent relative",
+  );
 
   env::set_current_dir(&second).expect("enter the second temporary directory");
   let second = env::current_dir().expect("read the second temporary directory");
+  let root = second.parent().expect("temporary directory has a parent");
+  let anchor = root.join("anchor");
+  let second_name = second.file_name().expect("second directory has a name");
+  let second_target = second.join("absolute-target.js");
+  let relative_target = Path::new("../second/relative-target.js");
+  let relative_base = Path::new("base");
+  assert_owned_relative(
+    relative_target,
+    relative_base,
+    &PathBuf::from("..").join("relative-target.js"),
+    "unequal-parent relative pair initializes cwd",
+  );
+  assert_owned_relative(
+    Path::new("entry.js"),
+    &anchor,
+    &PathBuf::from("..").join(second_name).join("entry.js"),
+    "relative receiver initializes cwd",
+  );
+  assert_owned_relative(
+    &second_target,
+    Path::new("base"),
+    &PathBuf::from("..").join("absolute-target.js"),
+    "relative base uses initialized cwd",
+  );
   assert_eq!(Path::new("entry.js").absolutize(), second.join("entry.js"));
 
   env::set_current_dir(&third).expect("enter the third temporary directory");
   let third = env::current_dir().expect("read the third temporary directory");
   let expected_base = if cfg!(feature = "cached_current_dir") { &second } else { &third };
+  let expected_base_name = expected_base.file_name().expect("expected base has a name");
+  let expected_relative_pair = if cfg!(feature = "cached_current_dir") {
+    PathBuf::from("..").join("relative-target.js")
+  } else {
+    PathBuf::from("..").join("..").join(second_name).join("relative-target.js")
+  };
+  assert_owned_relative(
+    relative_target,
+    relative_base,
+    &expected_relative_pair,
+    "unequal-parent relative pair observes cwd policy",
+  );
+  let expected_slash = if cfg!(feature = "cached_current_dir") {
+    "../relative-target.js"
+  } else {
+    "../../second/relative-target.js"
+  };
+  assert_eq!(
+    relative_target.relative(relative_base).into_owned().into_slash(),
+    expected_slash,
+    "strict relative-to-slash composition observes cwd policy",
+  );
+  assert_eq!(
+    relative_target
+      .try_relative(relative_base)
+      .expect("fixture should resolve against cwd")
+      .into_owned()
+      .into_slash(),
+    expected_slash,
+    "fallible relative-to-slash composition observes cwd policy",
+  );
+  let explicit = relative_target.relative_with(relative_base, &third);
+  assert_eq!(
+    explicit.as_os_str(),
+    PathBuf::from("..").join("..").join(second_name).join("relative-target.js").as_os_str(),
+    "explicit cwd must bypass ambient caching",
+  );
+  assert!(matches!(explicit, Cow::Owned(_)), "explicit unequal-parent result should own");
+  assert_owned_relative(
+    Path::new("entry.js"),
+    &anchor,
+    &PathBuf::from("..").join(expected_base_name).join("entry.js"),
+    "relative receiver observes cwd policy",
+  );
+  let expected_from_relative_base = if cfg!(feature = "cached_current_dir") {
+    PathBuf::from("..").join("absolute-target.js")
+  } else {
+    PathBuf::from("..").join("..").join(second_name).join("absolute-target.js")
+  };
+  assert_owned_relative(
+    &second_target,
+    Path::new("base"),
+    &expected_from_relative_base,
+    "relative base observes cwd policy",
+  );
   assert_eq!(Path::new("entry.js").absolutize(), expected_base.join("entry.js"));
 
   #[cfg(target_family = "windows")]
@@ -59,10 +155,27 @@ fn current_directory_is_cached_only_when_requested() {
     };
     let drive_relative = format!("{drive}:drive-entry.js");
     let oracle = std::path::absolute(&drive_relative).expect("resolve the drive-relative oracle");
+    assert_eq!(oracle, third.join("drive-entry.js"));
     assert_eq!(
       Path::new(&drive_relative).absolutize().as_ref(),
       oracle.as_path(),
       "drive-relative resolution must bypass the single cached cwd",
+    );
+    assert_owned_relative(
+      Path::new(&drive_relative),
+      &anchor,
+      &PathBuf::from("..").join("third").join("drive-entry.js"),
+      "drive-relative receiver bypasses cached cwd",
+    );
+
+    let drive_base = format!("{drive}:drive-base");
+    let base_oracle = std::path::absolute(&drive_base).expect("resolve drive-relative base oracle");
+    assert_eq!(base_oracle, third.join("drive-base"));
+    assert_owned_relative(
+      &second_target,
+      Path::new(&drive_base),
+      &PathBuf::from("..").join("..").join("second").join("absolute-target.js"),
+      "drive-relative base bypasses cached cwd",
     );
   }
 }

--- a/tests/cached_current_dir_failure.rs
+++ b/tests/cached_current_dir_failure.rs
@@ -1,0 +1,94 @@
+#![cfg(unix)]
+
+use std::{
+  borrow::Cow,
+  env, fs,
+  panic::{AssertUnwindSafe, catch_unwind},
+  path::{Path, PathBuf},
+  process::Command,
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use sugar_path::SugarPath;
+
+const CHILD_ENV: &str = "SUGAR_PATH_CACHED_CWD_FAILURE_ROOT";
+
+fn assert_owned_relative(target: &Path, base: &Path, expected: &Path, context: &str) {
+  let fallible = target.try_relative(base).expect("fixture should resolve against cwd");
+  assert_eq!(fallible.as_os_str(), expected.as_os_str(), "{context} try");
+  assert!(matches!(fallible, Cow::Owned(_)), "{context} try should own");
+
+  let strict = target.relative(base);
+  assert_eq!(strict.as_os_str(), expected.as_os_str(), "{context} strict");
+  assert!(matches!(strict, Cow::Owned(_)), "{context} strict should own");
+}
+
+#[test]
+fn failed_cwd_lookup_does_not_poison_later_relative_calls() {
+  if let Some(root) = env::var_os(CHILD_ENV) {
+    let root = PathBuf::from(root);
+    let doomed = root.join("doomed");
+    let recovery = root.join("recovery");
+    let later = root.join("later");
+    let anchor = root.join("anchor");
+
+    fs::remove_dir(&doomed).expect("remove the child's current directory");
+    assert!(env::current_dir().is_err());
+    assert!(Path::new("recovered.js").try_relative(&anchor).is_err());
+    assert!(
+      catch_unwind(AssertUnwindSafe(|| Path::new("recovered.js").relative(&anchor))).is_err(),
+      "strict relative should panic while cwd is unavailable",
+    );
+
+    env::set_current_dir(&recovery).expect("enter the recovery directory");
+    let recovery = env::current_dir().expect("read the recovery directory");
+    let anchor = recovery.parent().expect("recovery directory has a parent").join("anchor");
+    let recovery_name = recovery.file_name().expect("recovery directory has a name");
+    assert_owned_relative(
+      Path::new("recovered.js"),
+      &anchor,
+      &PathBuf::from("..").join(recovery_name).join("recovered.js"),
+      "first successful cwd lookup after failures",
+    );
+
+    env::set_current_dir(&later).expect("enter the later directory");
+    let later = env::current_dir().expect("read the later directory");
+    let expected_base = if cfg!(feature = "cached_current_dir") { &recovery } else { &later };
+    let expected_name = expected_base.file_name().expect("expected base has a name");
+    assert_owned_relative(
+      Path::new("recovered.js"),
+      &anchor,
+      &PathBuf::from("..").join(expected_name).join("recovered.js"),
+      "failed lookup does not poison cwd policy",
+    );
+    return;
+  }
+
+  let unique = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("system clock is after the Unix epoch")
+    .as_nanos();
+  let root =
+    env::temp_dir().join(format!("sugar-path-cached-cwd-failure-{}-{unique}", std::process::id()));
+  let doomed = root.join("doomed");
+  fs::create_dir_all(&doomed).expect("create the child's current directory");
+  fs::create_dir(root.join("recovery")).expect("create the recovery directory");
+  fs::create_dir(root.join("later")).expect("create the later directory");
+
+  let output = Command::new(env::current_exe().expect("find the integration-test executable"))
+    .args(["--exact", "failed_cwd_lookup_does_not_poison_later_relative_calls", "--nocapture"])
+    .env(CHILD_ENV, &root)
+    .current_dir(&doomed)
+    .output()
+    .expect("run the integration test in a child process");
+
+  if root.exists() {
+    fs::remove_dir_all(&root).expect("clean up the child's temporary directories");
+  }
+  assert!(
+    output.status.success(),
+    "child test failed\nstdout:\n{}\nstderr:\n{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr),
+  );
+}

--- a/tests/cached_current_dir_relative.rs
+++ b/tests/cached_current_dir_relative.rs
@@ -1,0 +1,107 @@
+use std::{
+  borrow::Cow,
+  env, fs,
+  path::{Path, PathBuf},
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use sugar_path::{SugarPath, SugarPathBuf};
+
+struct CurrentDirGuard {
+  original: PathBuf,
+  cleanup: PathBuf,
+}
+
+impl Drop for CurrentDirGuard {
+  fn drop(&mut self) {
+    env::set_current_dir(&self.original).expect("restore the original current directory");
+    fs::remove_dir_all(&self.cleanup).expect("remove the temporary directories");
+  }
+}
+
+fn assert_owned_relative(target: &Path, base: &Path, expected: &Path, context: &str) {
+  let strict = target.relative(base);
+  assert_eq!(strict.as_os_str(), expected.as_os_str(), "{context} strict");
+  assert!(matches!(strict, Cow::Owned(_)), "{context} strict should own");
+
+  let fallible = target.try_relative(base).expect("fixture should resolve against cwd");
+  assert_eq!(fallible.as_os_str(), expected.as_os_str(), "{context} try");
+  assert!(matches!(fallible, Cow::Owned(_)), "{context} try should own");
+}
+
+#[test]
+fn pure_relative_calls_initialize_and_observe_cwd_policy() {
+  let original = env::current_dir().expect("read the original current directory");
+  let unique = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("system clock is after the Unix epoch")
+    .as_nanos();
+  let root =
+    env::temp_dir().join(format!("sugar-path-relative-cwd-{}-{unique}", std::process::id()));
+  let first = root.join("first");
+  let second = root.join("second");
+  let third = root.join("third");
+  fs::create_dir_all(&first).expect("create the first temporary directory");
+  fs::create_dir_all(&second).expect("create the second temporary directory");
+  fs::create_dir_all(&third).expect("create the third temporary directory");
+  let _guard = CurrentDirGuard { original, cleanup: root };
+
+  env::set_current_dir(&first).expect("enter the first temporary directory");
+  assert_owned_relative(
+    Path::new("pkg/assets/./index.js"),
+    Path::new("pkg/chunks"),
+    &PathBuf::from("..").join("assets").join("index.js"),
+    "cwd-independent preflight",
+  );
+
+  env::set_current_dir(&second).expect("enter the second temporary directory");
+  let relative_target = Path::new("../second/relative-target.js");
+  let relative_base = Path::new("base");
+  let initialized = relative_target
+    .try_relative(relative_base)
+    .expect("unequal-parent fixture should resolve against cwd");
+  assert_eq!(initialized.as_os_str(), Path::new("../relative-target.js").as_os_str());
+  assert!(matches!(initialized, Cow::Owned(_)), "initial unequal-parent result should own");
+
+  env::set_current_dir(&third).expect("enter the third temporary directory");
+  let third = env::current_dir().expect("read the third temporary directory");
+  let expected = if cfg!(feature = "cached_current_dir") {
+    PathBuf::from("..").join("relative-target.js")
+  } else {
+    PathBuf::from("..").join("..").join("second").join("relative-target.js")
+  };
+  assert_owned_relative(
+    relative_target,
+    relative_base,
+    &expected,
+    "unequal-parent pair observes cwd policy",
+  );
+
+  let expected_slash = if cfg!(feature = "cached_current_dir") {
+    "../relative-target.js"
+  } else {
+    "../../second/relative-target.js"
+  };
+  assert_eq!(
+    relative_target.relative(relative_base).into_owned().into_slash(),
+    expected_slash,
+    "strict relative-to-slash composition observes cwd policy",
+  );
+  assert_eq!(
+    relative_target
+      .try_relative(relative_base)
+      .expect("fixture should resolve against cwd")
+      .into_owned()
+      .into_slash(),
+    expected_slash,
+    "fallible relative-to-slash composition observes cwd policy",
+  );
+
+  let explicit = relative_target.relative_with(relative_base, &third);
+  assert_eq!(
+    explicit.as_os_str(),
+    PathBuf::from("..").join("..").join("second").join("relative-target.js").as_os_str(),
+    "explicit cwd must bypass ambient caching",
+  );
+  assert!(matches!(explicit, Cow::Owned(_)), "explicit unequal-parent result should own");
+}

--- a/tests/cached_current_dir_relative.rs
+++ b/tests/cached_current_dir_relative.rs
@@ -60,7 +60,7 @@ fn pure_relative_calls_initialize_and_observe_cwd_policy() {
   let initialized = relative_target
     .try_relative(relative_base)
     .expect("unequal-parent fixture should resolve against cwd");
-  assert_eq!(initialized.as_os_str(), Path::new("../relative-target.js").as_os_str());
+  assert_eq!(initialized.as_os_str(), PathBuf::from("..").join("relative-target.js").as_os_str(),);
   assert!(matches!(initialized, Cow::Owned(_)), "initial unequal-parent result should own");
 
   env::set_current_dir(&third).expect("enter the third temporary directory");


### PR DESCRIPTION
## Summary

- Extend the cached-current-directory integration test across cwd-independent relative inputs, cwd-dependent pure-relative and mixed absolute/relative branches, strict and fallible results, and exact `Cow` ownership.
- Isolate the pure-relative cache lifecycle in its own integration-test process so no mixed branch can initialize the cache on its behalf.
- Verify that `relative(...).into_owned().into_slash()` follows the same cached-cwd policy while `relative_with` remains controlled only by its explicit cwd.
- Verify on Windows that drive-relative receiver and base inputs continue to use authoritative per-drive cwd state instead of the single cached process cwd.
- Add an isolated Unix child-process test proving that failed cwd lookups do not poison the cache and that the first later success can still become the cached value.
- Run the default-feature suite for the `sugar_path` package alone so workspace feature unification cannot silently enable `cached_current_dir`.

## Why

The existing cache test covered `absolutize`, but did not enforce the ambient `relative` branches or their final slash-conversion composition. The unavailable-cwd test proved errors while cwd stayed missing, but did not prove that the cache retries after a failure. These tests make the documented process-lifetime feature behavior explicit without changing the implementation.

## Impact

This changes tests and one CI command only. It does not change production code, dependencies, benchmarks, or allocation snapshots. The same CI correction is owned by Draft PR #52; carrying it here lets this PR produce valid standalone default/all-feature evidence, and it will disappear from this diff after #52 merges and this branch rebases.

## Validation

- `cargo +1.97.0 fmt --all --check`
- `git diff --check`
- `cargo +1.97.0 test --test cached_current_dir`
- `cargo +1.97.0 test --test cached_current_dir --all-features`
- `cargo +1.97.0 test --test cached_current_dir_failure`
- `cargo +1.97.0 test --test cached_current_dir_failure --all-features`
- `cargo +1.97.0 test -p sugar_path --test cached_current_dir_relative`
- `cargo +1.97.0 test -p sugar_path --all-features --test cached_current_dir_relative`
- `cargo +1.97.0 test -p sugar_path`
- `cargo +1.97.0 test --workspace --all-features`
- `cargo +1.97.0 clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo +1.97.0 doc --workspace --all-features --no-deps`
- Changed tests compile and pass Clippy for `x86_64-pc-windows-msvc`, with and without `cached_current_dir`, in a dependency-only harness

## Adversarial review

- Review found that the workspace's allocation tracker enabled `cached_current_dir` during the nominal default-feature job. The default job now selects only `sugar_path`.
- Review found that later mixed relative calls could initialize the cache even if the pure-relative branch did not. That lifecycle now runs in an isolated integration-test process and observes the third cwd immediately after one pure-relative lookup in the second cwd.
- The same reviewer rechecked both fixes and reported PASS for the code and test design.
- The first genuine default-feature Windows run then exposed a test-oracle bug: an expected relative path used a literal `/` instead of the native separator. The expectation now uses `PathBuf::join`, and the rerun passed on Windows.

Hosted CI passed all 9 checks. The logs confirm separate `cargo test --locked -p sugar_path` and workspace all-feature runs, with the cache lifecycle tests executing in both configurations on native Windows, Linux, and macOS. The unavailable-cwd recovery test also executes and passes on Linux and macOS.
