### PR TITLE
ci: restore tested trusted publishing

### DIFF
--- a/.agents/docs/README.md
+++ b/.agents/docs/README.md
@@ -28,3 +28,4 @@ Use this map to load only the context that bears on the work in front of you. Al
 - Historical Windows-GNU Docker/Wine reproduction → [Local Docker validation is opt-in](./conventions.md#local-docker-validation-is-opt-in) and [Windows GNU local execution gate](../../benchmarks/windows-gnu.md#local-execution-gate).
 - Performance strategy, baseline changes, Rolldown workloads, allocation work, or API performance → [Performance strategy](./performance-strategy.md).
 - Test fixtures, assertions, generated cases, or platform test coverage → [Testing conventions](./conventions.md) and [Semantic test strategy](./testing-strategy.md).
+- Release-plz, crates.io trusted publishing, or post-merge test sequencing → [Tested release workflow](./release.md).

--- a/.agents/docs/release.md
+++ b/.agents/docs/release.md
@@ -1,0 +1,15 @@
+# Tested release workflow
+
+## Event and test gate
+
+Crates.io trusted publishing accepts GitHub Actions identity tokens from `push`, `release`, and `workflow_dispatch` events, but rejects `workflow_run`. Release-plz therefore remains triggered by a `main` push and waits for the repository's `Test` workflow to report success for the exact same repository, `push` event, `main` branch, and commit SHA before either publishing or updating the release PR. The rejected `workflow_run` path was observed in [run 29387021998](https://github.com/hyfdev/sugar_path/actions/runs/29387021998), after its upstream [Test run 29386965193](https://github.com/hyfdev/sugar_path/actions/runs/29386965193) had succeeded for merge commit `c387d729e5d865b7b5d432d310f21e011cfb0d2a`.
+
+The first attempt for each `main` push shares one concurrency group, so a newer push requests cancellation of validation and release work for the superseded commit; cancellation cannot undo an external publish that has already completed. Manual reruns use a SHA-specific group, so rerunning an old release cannot cancel the current first attempt. After the exact Test run succeeds, each Release-plz job checks out an attached local `main`, verifies its local commit against the push SHA, and reconfirms the remote `main` SHA immediately before its write action. A failed or timed-out Test run fails the release gate and does not request a crates.io token. If Test is rerun successfully after that failure, rerun the Release-plz workflow for the same current `main` push; never rerun an older release as a substitute.
+
+The trusted-publishing job and every action with repository write access use full action commit SHAs, with the human-facing release line retained in comments. This prevents a movable action tag or branch from changing the reviewed publishing code between the exact-SHA Test and the release job. The pre-transfer success in run 29319137656 proves that the `push` event is accepted for trusted publishing, but it does not prove the current `hyfdev` owner configuration. The first post-merge `main` run must complete the crates.io token exchange; if crates.io rejects the current repository identity, rebuild the trusted publisher configuration for the transferred repository before retrying the same release.
+
+## Durable evidence
+
+- [Release workflow](../../.github/workflows/release.yml)
+- [Main test workflow](../../.github/workflows/test.yaml)
+- [Pre-transfer evidence that a push event can obtain a trusted-publishing token](https://github.com/hyfdev/sugar_path/actions/runs/29319137656)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,44 +3,94 @@ name: Release-plz
 permissions: {}
 
 on:
-  # A new main push starts a no-op run that cancels any release for the
-  # superseded commit before its Test workflow finishes.
   push:
-    branches:
-      - main
-  workflow_run:
-    workflows:
-      - Test
-    types:
-      - completed
     branches:
       - main
 
 concurrency:
-  # Keep release work for main single-threaded. Push-triggered runs have no
-  # eligible jobs, but they promptly cancel a release whose commit main replaced.
-  group: release-plz-main
+  # First attempts supersede older pushes; manual reruns are isolated by SHA so
+  # rerunning an old release cannot cancel the current main release.
+  group: ${{ github.run_attempt == 1 && 'release-plz-main' || format('release-plz-rerun-{0}', github.sha) }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  # Release unpublished packages.
+  tested-main:
+    name: Wait for successful Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The repository ID survives a rename or transfer; forks have a different ID.
+    if: ${{ github.repository_id == '470253326' }}
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for exact main Test run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TESTED_SHA: ${{ github.sha }}
+        run: |
+          deadline=$((SECONDS + 15 * 60))
+          while (( SECONDS < deadline )); do
+            response="$(gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/test.yaml/runs" \
+              -f branch=main \
+              -f event=push \
+              -f head_sha="$TESTED_SHA" \
+              -f per_page=10)"
+            test_run="$(jq -c --arg repo "$GITHUB_REPOSITORY" --arg sha "$TESTED_SHA" '
+              [.workflow_runs[]
+                | select(
+                    .name == "Test"
+                    and .path == ".github/workflows/test.yaml"
+                    and .event == "push"
+                    and .head_branch == "main"
+                    and .head_sha == $sha
+                    and .head_repository.full_name == $repo
+                    and .repository.full_name == $repo
+                  )]
+              | sort_by(.created_at)
+              | .[-1] // empty
+            ' <<< "$response")"
+
+            if [[ -z "$test_run" ]]; then
+              echo "waiting for Test to register for main commit $TESTED_SHA"
+              sleep 10
+              continue
+            fi
+
+            status="$(jq -r '.status' <<< "$test_run")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "$test_run")"
+            run_url="$(jq -r '.html_url' <<< "$test_run")"
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" == "success" ]]; then
+                echo "verified successful Test run: $run_url"
+                exit 0
+              fi
+              echo "::error title=Main Test did not pass::Test for $TESTED_SHA concluded $conclusion: $run_url"
+              exit 1
+            fi
+
+            echo "waiting for Test run $run_url (status: $status)"
+            sleep 10
+          done
+
+          echo "::error title=Main Test timed out::No successful completed Test run appeared for $TESTED_SHA within 15 minutes."
+          exit 1
+
+  # Release unpublished packages only after the exact main push passes Test.
   release-plz-release:
     name: Release-plz release
+    needs: tested-main
     runs-on: ubuntu-latest
-    if: >-
-      ${{ github.event_name == 'workflow_run'
-        && github.repository == 'hyfdev/sugar_path'
-        && github.event.workflow_run.event == 'push'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.head_branch == 'main'
-        && github.event.workflow_run.head_repository.full_name == github.repository }}
     permissions:
       contents: write
       id-token: write
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -48,35 +98,35 @@ jobs:
       - name: Verify tested main commit
         id: tested_main
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [[ "$(git rev-parse HEAD)" == "$TESTED_SHA" ]]; then
             echo "current=true" >> "$GITHUB_OUTPUT"
           else
             echo "current=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Superseded release::The tested main commit is no longer current; a newer Test run will handle the release."
+            echo "::notice title=Superseded release::The tested main commit is no longer current; the newer push will handle the release."
           fi
       - name: Install Rust toolchain
         if: ${{ steps.tested_main.outputs.current == 'true' }}
-        uses: dtolnay/rust-toolchain@stable
-      - uses: rust-lang/crates-io-auth-action@v1
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
         id: auth
         if: ${{ steps.tested_main.outputs.current == 'true' }}
       - name: Reconfirm tested main commit
         id: current_main
         if: ${{ steps.tested_main.outputs.current == 'true' }}
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [[ "$(git ls-remote --exit-code origin refs/heads/main | cut -f1)" == "$TESTED_SHA" ]]; then
             echo "current=true" >> "$GITHUB_OUTPUT"
           else
             echo "current=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Superseded release::Main advanced while preparing the release; a newer Test run will handle it."
+            echo "::notice title=Superseded release::Main advanced while preparing the release; the newer push will handle it."
           fi
       - name: Run release-plz
         if: ${{ steps.current_main.outputs.current == 'true' }}
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
         env:
@@ -86,20 +136,14 @@ jobs:
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
+    needs: tested-main
     runs-on: ubuntu-latest
-    if: >-
-      ${{ github.event_name == 'workflow_run'
-        && github.repository == 'hyfdev/sugar_path'
-        && github.event.workflow_run.event == 'push'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.head_branch == 'main'
-        && github.event.workflow_run.head_repository.full_name == github.repository }}
     permissions:
       contents: write
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -107,32 +151,32 @@ jobs:
       - name: Verify tested main commit
         id: tested_main
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [[ "$(git rev-parse HEAD)" == "$TESTED_SHA" ]]; then
             echo "current=true" >> "$GITHUB_OUTPUT"
           else
             echo "current=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Superseded release PR::The tested main commit is no longer current; a newer Test run will update the release PR."
+            echo "::notice title=Superseded release PR::The tested main commit is no longer current; the newer push will update the release PR."
           fi
       - name: Install Rust toolchain
         if: ${{ steps.tested_main.outputs.current == 'true' }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Reconfirm tested main commit
         id: current_main
         if: ${{ steps.tested_main.outputs.current == 'true' }}
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [[ "$(git ls-remote --exit-code origin refs/heads/main | cut -f1)" == "$TESTED_SHA" ]]; then
             echo "current=true" >> "$GITHUB_OUTPUT"
           else
             echo "current=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Superseded release PR::Main advanced while preparing the release PR; a newer Test run will update it."
+            echo "::notice title=Superseded release PR::Main advanced while preparing the release PR; the newer push will update it."
           fi
       - name: Run release-plz
         if: ${{ steps.current_main.outputs.current == 'true' }}
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary

- Keep Release-plz on the crates.io-supported `push` event, but wait for the exact same-repository, `main`, `push`, and commit-SHA Test run to succeed before release work starts.
- Preserve attached-`main` checkout plus local and remote SHA checks before either publishing or updating the release PR.
- Use the stable repository ID across rename or transfer and isolate manual reruns from current first attempts.
- Pin every action in the repository-write/OIDC workflow to a full commit SHA.
- Record the release failure, recovery procedure, concurrency limits, and current-owner verification requirement.

## Root cause

PR #59 correctly made the first post-merge Test run succeed for `c387d729e5d865b7b5d432d310f21e011cfb0d2a`, then triggered Release-plz for that exact SHA. The release PR job succeeded, but crates.io rejected the release job because trusted publishing does not accept the `workflow_run` event. The failed run is https://github.com/hyfdev/sugar_path/actions/runs/29387021998 and its successful upstream Test run is https://github.com/hyfdev/sugar_path/actions/runs/29386965193.

The prior repository-name guard would also have silently skipped all release work after another rename or transfer, and movable action references allowed privileged publishing code to change outside review.

## Impact

Publishing remains blocked until the exact post-merge `main` SHA passes the Test workflow, while the crates.io token exchange once again runs under a supported event. A rename or transfer now reaches an explicit token-exchange result instead of silently skipping, forks remain excluded by repository ID, and reviewed action code cannot move behind a tag or branch.

This PR changes no production path behavior, semantic test inventory, dependency, benchmark, or benchmark input.

## Validation

- `actionlint v1.7.12` passed the release workflow.
- The release API predicate selected live Test run `29386965193` only with the exact repository and SHA and rejected a mismatched repository.
- All pinned action SHAs resolve to the reviewed action commits and carry human-facing version comments.
- Two independent adversarial reviewers found the rename/transfer skip, movable privileged actions, old-rerun cancellation risk, and overbroad release documentation; all were fixed, and the final focused review passed.
- A final fresh two-reviewer full-scope round independently passed the exact-SHA gate, transfer/fork boundary, action pins, rerun concurrency, write-before-reconfirmation checks, documentation, and current-head CI.
- The [split-only hosted run](https://github.com/hyfdev/sugar_path/actions/runs/29389368964) passed all seven required checks across native Linux, Windows, macOS ARM64, WASIp1, lint, and both allocation snapshots; the release event itself can only execute after merge to `main`.

## Post-merge verification

Merge commit `356db0a955b99067c130d08db67a6cdfed7dff50` triggered [Test run 29393448029](https://github.com/hyfdev/sugar_path/actions/runs/29393448029), which passed all seven jobs. [Release-plz run 29393448017](https://github.com/hyfdev/sugar_path/actions/runs/29393448017) waited for that exact SHA, then its release-PR job succeeded. The publishing job reached crates.io authentication and received `No Trusted Publishing config found for repository hyfdev/sugar_path`; it stopped before release-plz could publish a package.

The `sugar_path` trusted-publisher entry was rebuilt with owner `hyfdev`, repository `sugar_path`, workflow filename `release.yml`, and no environment. Attempt 2 of the same run then passed the exact-SHA wait, obtained and revoked the short-lived crates.io token successfully, and completed both Release-plz jobs. Release-plz correctly reported that version 3.0.0 was already published, so it did not publish a duplicate package.
