### PR TITLE
ci: verify publishable package artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,6 +121,10 @@ jobs:
             echo "Rust host $EXPECTED_HOST is missing target feature $REQUIRED_TARGET_FEATURE"
             exit 1
           fi
+      - name: Verify native package artifact
+        run: |
+          cargo package --locked -p sugar_path
+          cargo package --locked -p sugar_path --features cached_current_dir
       # Clippy stays on each OS: platform-gated imports only fail under that target.
       - name: Clippy
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
@@ -178,6 +182,12 @@ jobs:
         run: |
           cargo check --locked -p sugar_path --lib --target wasm32-unknown-unknown --no-default-features
           cargo check --locked -p sugar_path --lib --target wasm32-unknown-unknown --no-default-features --features cached_current_dir
+      - name: Verify WebAssembly package artifacts
+        run: |
+          cargo package --locked -p sugar_path --target wasm32-unknown-unknown --no-default-features
+          cargo package --locked -p sugar_path --target wasm32-unknown-unknown --no-default-features --features cached_current_dir
+          cargo package --locked -p sugar_path --target wasm32-wasip1 --no-default-features
+          cargo package --locked -p sugar_path --target wasm32-wasip1 --no-default-features --features cached_current_dir
       - name: Install Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
         with:


### PR DESCRIPTION
## Summary

- verify the packaged crate, not only the checkout, on Linux, Windows, and macOS
- check both the default and `cached_current_dir` production configurations on each native host
- verify the same two configurations for `wasm32-unknown-unknown` and `wasm32-wasip1`

## Why

The existing source-tree checks can all pass while `cargo package` produces a crate that does not compile. A controlled mutation that excluded a required source file remained green under formatting, documentation, Clippy, and both test configurations, but failed when Cargo compiled the generated `.crate`.

The checks run on each supported native host because a host-only package verification can also miss an excluded Windows- or macOS-specific source file. The WebAssembly job performs the equivalent target-specific verification for both documented WASM targets.

## Validation

- packaged and verified the default and cached configurations for `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `wasm32-unknown-unknown`, and `wasm32-wasip1`
- `cargo fmt --all --check`
- workflow YAML parse and `git diff --check`
- two adversarial review rounds; the first found the default/platform blind spots, and the final round passed after the matrix was expanded
