### PR TITLE
fix: preserve borrowing for Windows drive-relative paths

### DIFF
--- a/.agents/docs/testing-strategy.md
+++ b/.agents/docs/testing-strategy.md
@@ -28,6 +28,10 @@ The matrix is interaction-aware. A platform root kind must be crossed with encod
 - Exact native spelling and encoding are asserted directly. `Path` equality and lossy conversion are insufficient when trailing separators, drive spelling, or invalid encoding are observable.
 - `Cow` and consuming APIs assert ownership separately from value equality. A test that checks only output text does not protect the allocation-facing contract.
 
+## Normalization coverage checkpoint
+
+- An independent public normalization model resolves its own root and component stack without calling SugarPath or `std::path::components`, then checks exact non-consuming and consuming results plus the non-consuming `Cow` contract for 6,560 Unix and 14,040 Windows inputs. The corpus crosses relative and rooted forms, drive-relative Windows paths, clean, redundant, forward-slash Windows and trailing separators, parents, current-directory components, dot-prefixed ordinary names, case-sensitive spelling, multibyte names, and Unix backslashes as ordinary bytes.
+
 ## Relative-path coverage checkpoint
 
 - `relative_with` has fixed Unix and Windows expected-output matrices for relative, absolute, mixed-context, dirty, equal, root-clamped, trailing-separator, root-relative, drive-relative, and different-drive results, using both borrowed and owned cwd arguments.
@@ -63,6 +67,7 @@ Any change to a public contract, platform branch, native-encoding comparison, cl
 - [Default/cached-current-directory configuration sentinel](../../tests/feature_configuration.rs)
 - [Fixed explicit and fallible relative matrices](../../tests/relative_lexical.rs)
 - [Independent bounded public relative model](../../tests/public_relative_model.rs)
+- [Independent bounded public normalization model](../../tests/public_normalize_model.rs)
 - [Relative ownership and lifetime contracts](../../tests/relative_borrowing.rs)
 - [Unavailable-cwd relative behavior](../../tests/relative_without_cwd.rs)
 - [Known-UTF-8 string receiver ownership](../../tests/string_receiver_contracts.rs)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,7 @@ jobs:
             expected_tests: |-
               impl_sugar_path::relative_str_tests::production_dispatch_and_suffix_validation_match_short_path_oracle
               impl_sugar_path::normalization_classifier_tests::unix_classifier_matches_full_normalizer_for_short_arbitrary_bytes
+              public_normalize_matches_the_bounded_independent_model
               public_relative_with_matches_the_bounded_independent_model
               unix::absolute_relative_common_prefix_compares_invalid_encoding_exactly
               utf8_string_receivers_borrow_only_from_the_receiver
@@ -75,6 +76,7 @@ jobs:
             expected_tests: |-
               windows_relative_with_has_fixed_context_results
               impl_sugar_path::normalization_classifier_tests::windows_classifier_matches_full_normalizer_for_short_arbitrary_wide_units
+              public_normalize_matches_the_bounded_independent_model
               public_relative_with_matches_the_bounded_independent_model
               encoded_root_identifiers_compare_only_ascii_case_and_exact_native_units
               absolutization_preserves_encoded_root_identifiers
@@ -89,6 +91,7 @@ jobs:
             expected_tests: |-
               absolute_relative_paths_cross_neon_block_boundaries_exactly
               impl_sugar_path::normalization_classifier_tests::unix_classifier_matches_full_normalizer_for_short_arbitrary_bytes
+              public_normalize_matches_the_bounded_independent_model
               public_relative_with_matches_the_bounded_independent_model
               unix::absolute_relative_common_prefix_compares_invalid_encoding_exactly
               utf8_string_receivers_borrow_only_from_the_receiver

--- a/src/impl_sugar_path.rs
+++ b/src/impl_sugar_path.rs
@@ -1202,6 +1202,22 @@ fn needs_normalization(path: &Path, trailing: TrailingSeparator) -> bool {
   {
     return true;
   }
+  // A drive-relative path can keep unresolved leading parents. Skip the
+  // generic `\..` rejection when the entire tail is already in canonical
+  // leading-parent form, such as `C:..\..\foo`.
+  if bytes.len() >= 4
+    && bytes[1] == b':'
+    && bytes[0].is_ascii_alphabetic()
+    && bytes[2] == b'.'
+    && bytes[3] == b'.'
+    && (bytes.len() == 4 || bytes[4] == b'\\')
+  {
+    return !leading_parent_path_is_normalized(
+      &bytes[2..],
+      b'\\',
+      trailing == TrailingSeparator::Preserve,
+    );
+  }
   // A leading `.` needs normalization. A leading run of `..` can be clean when
   // every remaining component is normal (`...` and `.foo` are normal names).
   if bytes[0] == b'.' {

--- a/tests/normalize.rs
+++ b/tests/normalize.rs
@@ -310,7 +310,15 @@ fn windows_dirty_paths_return_owned_cow() {
 #[cfg(target_family = "windows")]
 #[test]
 fn windows_canonical_leading_parent_paths_return_borrowed_cow() {
-  for path in [r"..", r"..\", r"..\foo", r"..\foo\", r"..\..\chunks\shared.js"] {
+  for path in [
+    r"..",
+    r"..\",
+    r"..\foo",
+    r"..\foo\",
+    r"..\..\chunks\shared.js",
+    r"C:..\..",
+    r"c:..\..\chunks\shared.js",
+  ] {
     let input = p!(path);
     let normalized = input.normalize();
     let Cow::Borrowed(borrowed) = normalized else {
@@ -328,6 +336,7 @@ fn windows_dirty_leading_parent_paths_return_owned_cow() {
     (r"..\foo\..", r".."),
     (r"..\foo\\bar", r"..\foo\bar"),
     (r"..\..\foo\..\bar", r"..\..\bar"),
+    (r"C:..\foo\..", r"C:.."),
   ] {
     let normalized = p!(path).normalize();
     assert!(matches!(normalized, Cow::Owned(_)), "expected owned Cow for dirty path {path:?}");

--- a/tests/owned_api.rs
+++ b/tests/owned_api.rs
@@ -23,6 +23,8 @@ fn into_normalized_reuses_clean_owned_buffers() {
   let cases = [
     r"C:\workspace\rolldown\crates\rolldown\src\module_loader\module_task.rs",
     r"..\..\chunks\shared.js",
+    r"C:..\..",
+    r"c:..\..\chunks\shared.js",
   ];
 
   for input in cases {

--- a/tests/public_normalize_model.rs
+++ b/tests/public_normalize_model.rs
@@ -1,0 +1,388 @@
+#![cfg(any(target_family = "unix", target_family = "windows"))]
+
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
+
+use sugar_path::{SugarPath, SugarPathBuf};
+
+const ATOMS: &[Atom] = &[
+  Atom::Name("a"),
+  Atom::Name("A"),
+  Atom::Name("b"),
+  Atom::Name("β"),
+  #[cfg(target_family = "unix")]
+  Atom::Name("literal\\"),
+  Atom::Name(".config"),
+  Atom::Name("..cache"),
+  Atom::Current,
+  Atom::Parent,
+];
+
+#[cfg(target_family = "unix")]
+const EXPECTED_CASES: usize = 6_560;
+#[cfg(target_family = "windows")]
+const EXPECTED_CASES: usize = 14_040;
+
+#[derive(Clone, Copy, Debug)]
+enum Atom {
+  Name(&'static str),
+  Current,
+  Parent,
+}
+
+impl Atom {
+  fn spelling(self) -> &'static str {
+    match self {
+      Self::Name(name) => name,
+      Self::Current => ".",
+      Self::Parent => "..",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InputRoot {
+  Relative,
+  #[cfg(target_family = "unix")]
+  Unix,
+  #[cfg(target_family = "windows")]
+  RootRelative,
+  #[cfg(target_family = "windows")]
+  Disk(u8),
+  #[cfg(target_family = "windows")]
+  DriveRelative(u8),
+}
+
+impl InputRoot {
+  fn is_rooted(self) -> bool {
+    match self {
+      Self::Relative => false,
+      #[cfg(target_family = "unix")]
+      Self::Unix => true,
+      #[cfg(target_family = "windows")]
+      Self::RootRelative | Self::Disk(_) => true,
+      #[cfg(target_family = "windows")]
+      Self::DriveRelative(_) => false,
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+struct InputCase {
+  root: InputRoot,
+  atoms: Vec<Atom>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SeparatorSpelling {
+  Native,
+  RedundantNative,
+  #[cfg(target_family = "windows")]
+  Forward,
+}
+
+impl SeparatorSpelling {
+  fn separator(self) -> &'static str {
+    match self {
+      Self::Native => native_separator(),
+      Self::RedundantNative => redundant_separator(),
+      #[cfg(target_family = "windows")]
+      Self::Forward => "/",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Mode {
+  name: &'static str,
+  separators: SeparatorSpelling,
+  trailing: bool,
+}
+
+#[cfg(target_family = "unix")]
+const MODES: &[Mode] = &[
+  Mode { name: "native", separators: SeparatorSpelling::Native, trailing: false },
+  Mode { name: "native_trailing", separators: SeparatorSpelling::Native, trailing: true },
+  Mode { name: "redundant", separators: SeparatorSpelling::RedundantNative, trailing: false },
+  Mode {
+    name: "redundant_trailing",
+    separators: SeparatorSpelling::RedundantNative,
+    trailing: true,
+  },
+];
+
+#[cfg(target_family = "windows")]
+const MODES: &[Mode] = &[
+  Mode { name: "native", separators: SeparatorSpelling::Native, trailing: false },
+  Mode { name: "native_trailing", separators: SeparatorSpelling::Native, trailing: true },
+  Mode { name: "redundant", separators: SeparatorSpelling::RedundantNative, trailing: false },
+  Mode {
+    name: "redundant_trailing",
+    separators: SeparatorSpelling::RedundantNative,
+    trailing: true,
+  },
+  Mode { name: "forward", separators: SeparatorSpelling::Forward, trailing: false },
+  Mode { name: "forward_trailing", separators: SeparatorSpelling::Forward, trailing: true },
+];
+
+#[derive(Clone, Copy, Debug)]
+enum NormalizedAtom {
+  Name(&'static str),
+  Parent,
+}
+
+#[cfg(target_family = "unix")]
+fn platform_name() -> &'static str {
+  "unix"
+}
+
+#[cfg(target_family = "windows")]
+fn platform_name() -> &'static str {
+  "windows"
+}
+
+#[cfg(target_family = "unix")]
+fn native_separator() -> &'static str {
+  "/"
+}
+
+#[cfg(target_family = "windows")]
+fn native_separator() -> &'static str {
+  r"\"
+}
+
+#[cfg(target_family = "unix")]
+fn redundant_separator() -> &'static str {
+  "//"
+}
+
+#[cfg(target_family = "windows")]
+fn redundant_separator() -> &'static str {
+  r"\\"
+}
+
+#[cfg(target_family = "unix")]
+fn root_separator(spelling: SeparatorSpelling) -> &'static str {
+  spelling.separator()
+}
+
+#[cfg(target_family = "windows")]
+fn root_separator(spelling: SeparatorSpelling) -> &'static str {
+  match spelling {
+    SeparatorSpelling::Forward => "/",
+    SeparatorSpelling::Native | SeparatorSpelling::RedundantNative => r"\",
+  }
+}
+
+fn roots() -> &'static [InputRoot] {
+  #[cfg(target_family = "unix")]
+  {
+    &[InputRoot::Relative, InputRoot::Unix]
+  }
+  #[cfg(target_family = "windows")]
+  {
+    &[
+      InputRoot::Relative,
+      InputRoot::RootRelative,
+      InputRoot::Disk(b'c'),
+      InputRoot::DriveRelative(b'c'),
+    ]
+  }
+}
+
+fn generated_atom_sequences() -> Vec<Vec<Atom>> {
+  let mut sequences = Vec::new();
+  for depth in 0..=3 {
+    for mut ordinal in 0..ATOMS.len().pow(depth) {
+      let mut sequence = Vec::with_capacity(depth as usize);
+      for _ in 0..depth {
+        sequence.push(ATOMS[ordinal % ATOMS.len()]);
+        ordinal /= ATOMS.len();
+      }
+      sequences.push(sequence);
+    }
+  }
+  sequences
+}
+
+fn generated_cases() -> Vec<InputCase> {
+  generated_atom_sequences()
+    .into_iter()
+    .flat_map(|atoms| {
+      roots().iter().map(move |root| InputCase { root: *root, atoms: atoms.clone() })
+    })
+    .collect()
+}
+
+fn render_input(case: &InputCase, mode: Mode) -> String {
+  let separator = mode.separators.separator();
+  let mut rendered = match case.root {
+    InputRoot::Relative => String::new(),
+    #[cfg(target_family = "unix")]
+    InputRoot::Unix => String::from(root_separator(mode.separators)),
+    #[cfg(target_family = "windows")]
+    InputRoot::RootRelative => String::from(root_separator(mode.separators)),
+    #[cfg(target_family = "windows")]
+    InputRoot::Disk(drive) => {
+      format!("{}:{}", char::from(drive), root_separator(mode.separators))
+    }
+    #[cfg(target_family = "windows")]
+    InputRoot::DriveRelative(drive) => format!("{}:", char::from(drive)),
+  };
+
+  for (index, atom) in case.atoms.iter().enumerate() {
+    if index > 0 {
+      rendered.push_str(separator);
+    }
+    rendered.push_str(atom.spelling());
+  }
+  if mode.trailing && !case.atoms.is_empty() {
+    rendered.push_str(separator);
+  }
+  rendered
+}
+
+fn normalized_atoms(case: &InputCase) -> Vec<NormalizedAtom> {
+  let mut normalized = Vec::new();
+  for atom in &case.atoms {
+    match *atom {
+      Atom::Name(name) => normalized.push(NormalizedAtom::Name(name)),
+      Atom::Current => {}
+      Atom::Parent => match normalized.last() {
+        Some(NormalizedAtom::Name(_)) => {
+          normalized.pop();
+        }
+        Some(NormalizedAtom::Parent) | None if !case.root.is_rooted() => {
+          normalized.push(NormalizedAtom::Parent);
+        }
+        Some(NormalizedAtom::Parent) | None => {}
+      },
+    }
+  }
+  normalized
+}
+
+fn expected_normalized(case: &InputCase, input: &str) -> PathBuf {
+  let components = normalized_atoms(case);
+  let mut expected = match case.root {
+    InputRoot::Relative => String::new(),
+    #[cfg(target_family = "unix")]
+    InputRoot::Unix => String::from("/"),
+    #[cfg(target_family = "windows")]
+    InputRoot::RootRelative => String::from(r"\"),
+    #[cfg(target_family = "windows")]
+    InputRoot::Disk(drive) => format!("{}:\\", char::from(drive)),
+    #[cfg(target_family = "windows")]
+    InputRoot::DriveRelative(drive) => format!("{}:", char::from(drive)),
+  };
+
+  for (index, component) in components.iter().enumerate() {
+    if index > 0 {
+      expected.push_str(native_separator());
+    }
+    match component {
+      NormalizedAtom::Name(name) => expected.push_str(name),
+      NormalizedAtom::Parent => expected.push_str(".."),
+    }
+  }
+
+  if components.is_empty() {
+    match case.root {
+      InputRoot::Relative => expected.push('.'),
+      #[cfg(target_family = "windows")]
+      InputRoot::DriveRelative(_) => expected.push('.'),
+      #[cfg(target_family = "unix")]
+      InputRoot::Unix => {}
+      #[cfg(target_family = "windows")]
+      InputRoot::RootRelative | InputRoot::Disk(_) => {}
+    }
+  }
+
+  if has_trailing_separator(input)
+    && (!components.is_empty() || !case.root.is_rooted())
+    && !expected.ends_with(native_separator())
+  {
+    expected.push_str(native_separator());
+  }
+  PathBuf::from(expected)
+}
+
+fn has_trailing_separator(input: &str) -> bool {
+  #[cfg(target_family = "unix")]
+  {
+    input.ends_with('/')
+  }
+  #[cfg(target_family = "windows")]
+  {
+    input.ends_with(['/', '\\'])
+  }
+}
+
+#[test]
+fn public_normalize_matches_the_bounded_independent_model() {
+  let cases = generated_cases();
+  let mut comparisons = 0;
+
+  for mode in MODES {
+    for case in &cases {
+      let input = render_input(case, *mode);
+      let expected = expected_normalized(case, &input);
+      let receiver = Path::new(&input);
+      let non_consuming = receiver.normalize();
+      let consumed = PathBuf::from(&input).into_normalized();
+      comparisons += 1;
+
+      assert_eq!(
+        non_consuming.as_os_str(),
+        expected.as_os_str(),
+        "non-consuming: platform={}; mode={}; case={case:?}; input={input:?}; expected={:?}; actual={:?}",
+        platform_name(),
+        mode.name,
+        expected.as_os_str(),
+        non_consuming.as_os_str(),
+      );
+
+      let input_is_expected = receiver.as_os_str() == expected.as_os_str();
+      let expected_is_static_dot = expected.as_os_str() == Path::new(".").as_os_str();
+      match non_consuming {
+        Cow::Borrowed(actual) => {
+          assert!(
+            input_is_expected || expected_is_static_dot,
+            "unexpected borrow: platform={}; mode={}; case={case:?}; input={input:?}; actual={:?}",
+            platform_name(),
+            mode.name,
+            actual.as_os_str(),
+          );
+          if input_is_expected {
+            assert!(
+              std::ptr::eq(actual, receiver),
+              "borrow source: platform={}; mode={}; case={case:?}; input={input:?}",
+              platform_name(),
+              mode.name,
+            );
+          }
+        }
+        Cow::Owned(_) => assert!(
+          !input_is_expected && !expected_is_static_dot,
+          "unexpected allocation: platform={}; mode={}; case={case:?}; input={input:?}; expected={:?}",
+          platform_name(),
+          mode.name,
+          expected.as_os_str(),
+        ),
+      }
+      assert_eq!(
+        consumed.as_os_str(),
+        expected.as_os_str(),
+        "consuming: platform={}; mode={}; case={case:?}; input={input:?}; expected={:?}; actual={:?}",
+        platform_name(),
+        mode.name,
+        expected.as_os_str(),
+        consumed.as_os_str(),
+      );
+    }
+  }
+
+  assert_eq!(comparisons, EXPECTED_CASES);
+}


### PR DESCRIPTION
## Summary

- add an independent bounded oracle for public `normalize` and `into_normalized` semantics
- cover 6,560 Unix and 14,040 Windows cases across roots, drive-relative paths, components, separator spellings, trailing separators, Unicode, and case preservation
- verify exact results, `Cow` ownership, borrow source, and consuming results
- preserve borrowing and owned-buffer reuse for normalized Windows drive-relative leading-parent paths such as `C:..\..`

## Why

The existing classifier test compares the production classifier with the production normalizer. It protects output equality, but cannot independently validate public normalization semantics or detect an unnecessary allocation when both paths produce the same value.

The new model exposed a real classifier gap: the generic Windows scan treated the second `\..` in `C:..\..` as requiring normalization. Drive-relative leading parents cannot be collapsed, so the normalizer rebuilt an identical path and returned an owned result.

The classifier now recognizes canonical drive-relative leading-parent tails while still rejecting duplicate separators, current-directory components, trailing separators in strip mode, and parents that follow a normal component.

## Impact

- public output semantics are unchanged
- canonical Windows drive-relative leading-parent paths now return `Cow::Borrowed`
- `into_normalized` reuses the original owned buffer for those paths
- paths that actually require normalization still return an owned result

## Validation

- default and `cached_current_dir` workspace tests
- full Clippy with warnings denied
- documentation and package verification
- Windows MSVC library and integration-test metadata compilation
- native Linux, Windows, macOS, and WebAssembly CI
- Linux and Windows allocation snapshots
- CodSpeed: 228 unchanged benchmarks
- final adversarial review: pass
