### PR TITLE
test: preserve non-UTF-8 ambient cwd

### DIFF
--- a/.agents/docs/testing-strategy.md
+++ b/.agents/docs/testing-strategy.md
@@ -43,6 +43,7 @@ The matrix is interaction-aware. A platform root kind must be crossed with encod
 - Windows drive-relative rows apply the same exact comparison before shared-context cancellation and preserve invalid-wide components while resolving against explicit borrowed and owned cwd arguments.
 - Unavailable Unix cwd coverage pins exact successful output and `Cow` variants for cwd-independent fallible calls, preserves the ambient error and panic checks for dependent `Path`, `str`, and `String` calls, and proves that a valid explicit cwd still succeeds.
 - Known-UTF-8 `str` and `String` receivers prove exact clean-trailing and dirty normalization contracts, receiver-only borrowing, explicit and ambient relative context forwarding, and cached-cwd behavior on Unix and Windows. Unix deleted-cwd rows also prove cwd-independent success and strict cwd-dependent panics for string receivers.
+- A Linux child process starts in a real cwd containing an invalid native byte and requires `absolutize`, `try_absolutize`, `relative`, and `try_relative` to preserve that byte exactly under both cwd policies. Linux supplies this executable filesystem case because macOS rejects the invalid-byte directory name; explicit-cwd tests continue to cover native-invalid Unix composition independently of the host filesystem.
 
 ## Follow-up coverage status
 
@@ -71,5 +72,6 @@ Any change to a public contract, platform branch, native-encoding comparison, cl
 - [Relative ownership and lifetime contracts](../../tests/relative_borrowing.rs)
 - [Unavailable-cwd relative behavior](../../tests/relative_without_cwd.rs)
 - [Known-UTF-8 string receiver ownership](../../tests/string_receiver_contracts.rs)
+- [Native-invalid ambient cwd preservation](../../tests/non_utf8_ambient_cwd.rs)
 - [Native-invalid exact comparison](../../tests/invalid_encoding.rs)
 - [Production dispatch and short-path oracle](../../src/impl_sugar_path.rs)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,7 @@ jobs:
               current_directory_is_cached_only_when_requested
               pure_relative_calls_initialize_and_observe_cwd_policy
               failed_cwd_lookup_does_not_poison_later_relative_calls
+              non_utf8_ambient_cwd_is_preserved
               requested_cached_current_dir_configuration_is_active
           - os: windows-latest
             expected_host: x86_64-pc-windows-msvc

--- a/tests/non_utf8_ambient_cwd.rs
+++ b/tests/non_utf8_ambient_cwd.rs
@@ -1,0 +1,90 @@
+#![cfg(target_os = "linux")]
+
+use std::{
+  env,
+  ffi::OsString,
+  fs,
+  os::unix::ffi::{OsStrExt, OsStringExt},
+  path::{Path, PathBuf},
+  process::Command,
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use sugar_path::SugarPath;
+
+const CHILD_ENV: &str = "SUGAR_PATH_NON_UTF8_AMBIENT_CWD_CHILD";
+const NON_UTF8_COMPONENT: &[u8] = b"non_utf8-\x80";
+
+fn assert_exact_path(actual: &Path, expected: &Path, context: &str) {
+  assert_eq!(
+    actual.as_os_str().as_bytes(),
+    expected.as_os_str().as_bytes(),
+    "{context} must preserve native cwd bytes",
+  );
+}
+
+#[test]
+fn non_utf8_ambient_cwd_is_preserved() {
+  if env::var_os(CHILD_ENV).is_some() {
+    let non_utf8_component = OsString::from_vec(NON_UTF8_COMPONENT.to_vec());
+    let cwd = env::current_dir().expect("read the child's current directory");
+    assert!(
+      cwd
+        .as_os_str()
+        .as_bytes()
+        .windows(NON_UTF8_COMPONENT.len())
+        .any(|window| window == NON_UTF8_COMPONENT),
+      "test setup must enter the non-UTF-8 cwd",
+    );
+    let root = cwd
+      .parent()
+      .and_then(Path::parent)
+      .expect("the child cwd has the temporary root as a grandparent");
+
+    let input = Path::new("pkg/entry.js");
+    let expected_absolute = cwd.join(input);
+    assert_exact_path(input.absolutize().as_ref(), &expected_absolute, "absolutize");
+    assert_exact_path(
+      input.try_absolutize().expect("resolve against the native cwd").as_ref(),
+      &expected_absolute,
+      "try_absolutize",
+    );
+
+    let target = Path::new("target.js");
+    let base = root.join("anchor");
+    let expected_relative = PathBuf::from("..").join(&non_utf8_component).join("leaf").join(target);
+    assert_exact_path(target.relative(&base).as_ref(), &expected_relative, "relative");
+    assert_exact_path(
+      target.try_relative(&base).expect("resolve relative paths against the native cwd").as_ref(),
+      &expected_relative,
+      "try_relative",
+    );
+    return;
+  }
+
+  let unique = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("system clock is after the Unix epoch")
+    .as_nanos();
+  let root =
+    env::temp_dir().join(format!("sugar-path-non-utf8-cwd-{}-{unique}", std::process::id()));
+  let cwd = root.join(OsString::from_vec(NON_UTF8_COMPONENT.to_vec())).join("leaf");
+  fs::create_dir_all(&cwd).expect("create the non-UTF-8 child cwd");
+
+  let output = Command::new(env::current_exe().expect("find the integration-test executable"))
+    .args(["--exact", "non_utf8_ambient_cwd_is_preserved", "--nocapture"])
+    .env(CHILD_ENV, "1")
+    .current_dir(&cwd)
+    .output()
+    .expect("run the integration test in a child process");
+
+  if root.exists() {
+    fs::remove_dir_all(&root).expect("clean up the non-UTF-8 child cwd");
+  }
+  assert!(
+    output.status.success(),
+    "child test failed\nstdout:\n{}\nstderr:\n{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr),
+  );
+}


### PR DESCRIPTION
## Summary

- add a Linux-only child-process test that starts from a real cwd containing the invalid native byte `0x80`
- require `absolutize`, `try_absolutize`, `relative`, and `try_relative` to preserve the cwd bytes exactly
- execute the contract under both default and `cached_current_dir` configurations through the native CI inventory
- record the ambient native-encoding coverage in the testing strategy

## Why

Existing tests cover non-UTF-8 inputs with an ordinary ambient cwd and non-UTF-8 explicit cwd arguments, but not an ambient cwd whose own filesystem spelling is non-UTF-8.

A controlled mutation rebuilt cwd through `to_string_lossy()` in both feature branches. The existing complete default and cached suites remained green, even though the mutation changes the native byte `0x80` into the UTF-8 replacement sequence `EF BF BD` before all four ambient APIs use it.

The new test runs in a fresh integration-test child process so the cached cwd cannot be initialized by the parent. It derives expected paths from `std::env::current_dir()` and compares raw bytes, without imposing a `Cow` or allocation requirement on the non-UTF-8 case.

## Platform scope

Linux supplies the executable filesystem case because macOS rejects the invalid-byte directory name with `EILSEQ`. The test is therefore required only in the native Linux inventory; explicit-cwd tests continue to cover native-invalid Unix composition independently of the host filesystem.

## Validation

- complete default suite: pass
- complete `cached_current_dir` workspace suite: pass
- full Clippy with warnings denied: pass
- documentation and package verification: pass
- Linux library and integration-test metadata cross-compilation: pass
- controlled lossy-cwd mutation: previous default 112 and cached 113 tests remained green
- native Linux child-process test: pass under default and `cached_current_dir`
- native Linux required-test registration: pass
- all seven hosted checks: pass
- independent adversarial review: pass
